### PR TITLE
ATsec project: VAST ⇄ Syslog

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -66,6 +66,7 @@ set(libvast_sources
     src/format/ostream_writer.cpp
     src/format/reader.cpp
     src/format/single_layout_reader.cpp
+    # TODO: add src/formaat/syslog.cpp here
     src/format/test.cpp
     src/format/writer.cpp
     src/format/zeek.cpp
@@ -254,6 +255,7 @@ set(tests
     test/format/csv.cpp
     test/format/json.cpp
     test/format/mrt.cpp
+    # TODO: add test/format/syslog.cpp here.
     test/format/writer.cpp
     test/format/zeek.cpp
     test/hash.cpp

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -1,0 +1,20 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/format/syslog.hpp"
+
+namespace vast::format::mrt {
+
+// TODO: implement functions here that do not belong into the header file. 
+
+} // namespace vast::format::mrt

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -153,6 +153,8 @@ auto make_import_command() {
   import_->add_subcommand("suricata", "imports suricata eve json",
                           documentation::vast_import_suricata,
                           source_opts("?import.suricata"));
+  // TODO: hook syslog reader into CLI here by adding a new subcommand. The
+  //       documentation goes into doc/cli/vast-import-syslog.md
   import_->add_subcommand("test",
                           "imports random data for testing or benchmarking",
                           documentation::vast_import_test,
@@ -337,6 +339,8 @@ auto make_command_factory() {
     {"import suricata",
      reader_command<format::json::reader<format::json::suricata>,
                     defaults::import::suricata>},
+    // TODO: hook syslog reader into CLI here by registering the command
+    //       callback. The defaults go into livvast/vast/defaults.hpp.
     {"import test",
      generator_command<format::test::reader, defaults::import::test>},
     {"import zeek",

--- a/libvast/test/format/syslog.cpp
+++ b/libvast/test/format/syslog.cpp
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#define SUITE format
+
+#include "vast/format/mrt.hpp"
+
+#include "vast/test/data.hpp"
+#include "vast/test/test.hpp"
+
+#include "vast/test/fixtures/actor_system.hpp"
+
+// TODO: you're likely gonna need these, too
+// #include "vast/concept/parseable/to.hpp"
+// #include "vast/defaults.hpp"
+// #include "vast/detail/make_io_stream.hpp"
+// #include "vast/filesystem.hpp"
+// #include "vast/to_events.hpp"
+
+using namespace vast;
+
+// Technically, we don't need the actor system. However, we do need to
+// initialize the table slice builder factories which happens automatically in
+// the actor system setup. Further, including this fixture gives us access to
+// log files to hunt down bugs faster.
+FIXTURE_SCOPE(syslog_tests, fixtures::deterministic_actor_system)
+
+TEST(Syslog) {
+  // TODO: implement tests here for Syslog parser and reader.
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/vast/format/syslog.hpp
+++ b/libvast/vast/format/syslog.hpp
@@ -1,0 +1,29 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+namespace vast::format::syslog {
+
+// TODO: implement a syslog parser using VAST's parser DSL.
+// TODO: implement a reader class that allows reading syslog files.
+
+// For inspiration, take a look at these files:
+// - libvast/vast/concept/parseable/*
+//    All files in parseable/ build the foundation if VAST's parser DSL.
+// - libvast/vast/format/mrt.hpp 
+//    mrt.hpp also includes a parser, which is necessary for syslog, too.
+// - libvast/vast/format/zeek.hpp, libvast/vast/format/pcap.hpp
+//    These are easy to read reader/writer implementations.
+
+} // namespace vast::format::syslog


### PR DESCRIPTION
Hey there.

This pull request adds initial scaffolding to VAST for the Syslog integration as part of your university project ATsec. The project can be divided into three steps, which should each correspond to separate pull requests in the [tenzir/vast repository](https://github.com/tenzir/vast). They are detailed and split up into individual tasks below.

Here's a quick guide to building and running VAST so you can play around with it.

```sh
# Check out submodules
git submodule update --init --recursive

# Build configuration
# NOTE: There are many flags for configure. E.g., I use this most of the time:
#       ./configure --dev-mode --extra-flags="-ferror-limit=1"
./configure

# Build
# NOTE: "build" is the default directory for out-of-source builds. You can have
#       multiple build configurations at the same time.
cmake --build build --target all

# Run tests
cmake --build build --target test

# Run integration tests
cmake --build build --target integration

# Run VAST
./build/bin/vast start
```

For communication, we'd prefer getting questions in our [Gitter chat](https://gitter.im/tenzir/chat). Feel free to ask for help with anything VAST, Syslog, Git, or whatever else related to the project you're having trouble with. We prefer you asking to trying blindly for hours if you're stuck. 🙂

We have a [contributing guide](https://github.com/tenzir/.github) as well, which has some guidelines on how to contribute to VAST.

### PR 1 — Write Syslog parser

Create a parser in VAST's parser DSL for the Syslog protocol.

- Implement [RFC5424 – The Syslog Protocol](https://tools.ietf.org/html/rfc5424)
- Write unit tests to test C++ code
- Write integration tests with real-world syslog traces

### PR 2 — Hook Syslog parser into CLI

Write a VAST schema generator for osquery queries.

- Write a new Syslog reader/subcommand
- Make it possible to select message/payload format
- Make it possible to merge Syslog meta data with payload data
- (optional) Create heuristic to infer the payload type and select parser
- (optional) Support string tokenization via regex and dynamic data extraction

### PR 3 — Integrate osquery via Syslog

After VAST can handle arbitrary syslog data, we can use this feature to demonstrate the integration with [osquery](https://osquery.readthedocs.io/en/latest/).

This is not to be confused with osquery's ability to [*consume* Syslog data via rsyslog](https://osquery.readthedocs.io/en/latest/deployment/syslog/).

- Develop demo scenario
- Test with hand-written VAST schema for an osquery
- Write a VAST schema generator for osquery queries